### PR TITLE
Testing lowering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,7 @@ find_package(MLIR REQUIRED CONFIG)
 
 message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+
+include(AddLLVM)
+
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+configure_lit_site_cfg(
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+        ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+        MAIN_CONFIG
+        ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+)
+
+set (MLIR_TUTORIAL_TEST_DEPENDS
+    FileCheck count not
+    mlir-opt
+    mlir-cpu-runner
+)
+
+add_lit_testsuite(check-mlir-tutorial "Running the MLIR tutorial regression tests"
+    ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${MLIR_TUTORIAL_TEST_DEPENDS}
+)

--- a/tests/ctlz.mlir
+++ b/tests/ctlz.mlir
@@ -1,0 +1,43 @@
+// RUN: mlir-opt %s --convert-math-to-funcs=convert-ctlz | FileCheck %s
+
+func.func @main(%arg0: i32) {
+  %0 = math.ctlz %arg0 : i32
+  func.return
+}
+// CHECK-LABEL:   func.func @main(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32
+// CHECK-SAME:                       ) {
+// CHECK:           %[[VAL_1:.*]] = call @__mlir_math_ctlz_i32(%[[VAL_0]]) : (i32) -> i32
+// CHECK:           return
+// CHECK:         }
+
+// CHECK-LABEL:   func.func private @__mlir_math_ctlz_i32(
+// CHECK-SAME:            %[[ARG:.*]]: i32
+// CHECK-SAME:            ) -> i32 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK:           %[[C_32:.*]] = arith.constant 32 : i32
+// CHECK:           %[[C_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[ARGCMP:.*]] = arith.cmpi eq, %[[ARG]], %[[C_0]] : i32
+// CHECK:           %[[OUT:.*]] = scf.if %[[ARGCMP]] -> (i32) {
+// CHECK:             scf.yield %[[C_32]] : i32
+// CHECK:           } else {
+// CHECK:             %[[C_1INDEX:.*]] = arith.constant 1 : index
+// CHECK:             %[[C_1I32:.*]] = arith.constant 1 : i32
+// CHECK:             %[[C_32INDEX:.*]] = arith.constant 32 : index
+// CHECK:             %[[N:.*]] = arith.constant 0 : i32
+// CHECK:             %[[FOR_RET:.*]]:2 = scf.for %[[I:.*]] = %[[C_1INDEX]] to %[[C_32INDEX]] step %[[C_1INDEX]]
+// CHECK:                 iter_args(%[[ARG_ITER:.*]] = %[[ARG]], %[[N_ITER:.*]] = %[[N]]) -> (i32, i32) {
+// CHECK:               %[[COND:.*]] = arith.cmpi slt, %[[ARG_ITER]], %[[C_0]] : i32
+// CHECK:               %[[IF_RET:.*]]:2 = scf.if %[[COND]] -> (i32, i32) {
+// CHECK:                 scf.yield %[[ARG_ITER]], %[[N_ITER]] : i32, i32
+// CHECK:               } else {
+// CHECK:                 %[[N_NEXT:.*]] = arith.addi %[[N_ITER]], %[[C_1I32]] : i32
+// CHECK:                 %[[ARG_NEXT:.*]] = arith.shli %[[ARG_ITER]], %[[C_1I32]] : i32
+// CHECK:                 scf.yield %[[ARG_NEXT]], %[[N_NEXT]] : i32, i32
+// CHECK:               }
+// CHECK:               scf.yield %[[IF_RET]]#0, %[[IF_RET]]#1 : i32, i32
+// CHECK:             }
+// CHECK:             scf.yield %[[FOR_RET]]#1 : i32
+// CHECK:           }
+// CHECK:           return %[[OUT]] : i32
+// CHECK:         }
+// NOCVT-NOT: __mlir_math_ctlz_i32

--- a/tests/ctlz_runner.mlir
+++ b/tests/ctlz_runner.mlir
@@ -1,0 +1,33 @@
+// RUN: mlir-opt %s \
+// RUN:   -pass-pipeline="builtin.module( \
+// RUN:      convert-math-to-funcs{convert-ctlz}, \
+// RUN:      func.func(convert-scf-to-cf,convert-arith-to-llvm), \
+// RUN:      convert-func-to-llvm, \
+// RUN:      convert-cf-to-llvm, \
+// RUN:      reconcile-unrealized-casts)" \
+// RUN: | mlir-cpu-runner -e test_7i32_to_29 -entry-point-result=i32 > %t
+// RUN: FileCheck %s --check-prefix=CHECK_TEST_7i32_TO_29 < %t
+
+func.func @test_7i32_to_29() -> i32 {
+  %arg = arith.constant 7 : i32
+  %0 = math.ctlz %arg : i32
+  func.return %0 : i32
+}
+// CHECK_TEST_7i32_TO_29: 29
+
+
+// RUN: mlir-opt %s \
+// RUN:   -pass-pipeline="builtin.module( \
+// RUN:      convert-math-to-funcs{convert-ctlz}, \
+// RUN:      func.func(convert-scf-to-cf,convert-arith-to-llvm), \
+// RUN:      convert-func-to-llvm, \
+// RUN:      convert-cf-to-llvm, \
+// RUN:      reconcile-unrealized-casts)" \
+// RUN: | mlir-cpu-runner -e test_7i64_to_61 -entry-point-result=i64 > %t
+// RUN:  FileCheck %s --check-prefix=CHECK_TEST_7i64_TO_61 < %t
+func.func @test_7i64_to_61() -> i64 {
+  %arg = arith.constant 7 : i64
+  %0 = math.ctlz %arg : i64
+  func.return %0 : i64
+}
+// CHECK_TEST_7i64_TO_61: 61

--- a/tests/ctlz_simple.mlir
+++ b/tests/ctlz_simple.mlir
@@ -1,0 +1,8 @@
+// RUN: mlir-opt %s --convert-math-to-funcs=convert-ctlz | FileCheck %s
+
+func.func @main(%arg0: i32) -> i32 {
+  // CHECK-NOT:  math.ctlz
+  // CHECK:  call
+  %0 = math.ctlz %arg0 : i32
+  func.return %0 : i32
+}

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -1,0 +1,69 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import subprocess
+import tempfile
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+from lit.llvm.subst import ToolSubst
+from lit.llvm.subst import FindTool
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = "MLIR_TUTORIAL"
+
+config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = [".mlir"]
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.project_binary_dir, "tests")
+
+config.substitutions.append(("%PATH%", config.environment["PATH"]))
+config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
+
+llvm_config.with_system_environment(["HOME", "INCLUDE", "LIB", "TMP", "TEMP"])
+
+llvm_config.use_default_substitutions()
+
+# excludes: A list of directories to exclude from the testsuite. The 'Inputs'
+# subdirectories contain auxiliary inputs for various tests in their parent
+# directories.
+config.excludes = ["Inputs", "Examples", "CMakeLists.txt", "README.txt", "LICENSE.txt"]
+
+# test_exec_root: The root path where tests should be run.
+# config.test_exec_root = os.path.join(config.standalone_obj_root, "test")
+# config.standalone_tools_dir = os.path.join(config.standalone_obj_root, "bin")
+# config.standalone_libs_dir = os.path.join(config.standalone_obj_root, "lib")
+
+# config.substitutions.append(("%standalone_libs", config.standalone_libs_dir))
+
+# Tweak the PATH to include the tools dir.
+llvm_config.with_environment("PATH", config.llvm_tools_dir, append_path=True)
+
+# tool_dirs = [config.standalone_tools_dir, config.llvm_tools_dir]
+tool_dirs = [config.llvm_tools_dir]
+tools = [
+    "mlir-opt",
+    "mlir-cpu-runner",
+]
+
+llvm_config.add_tool_substitutions(tools, tool_dirs)
+
+# llvm_config.with_environment(
+#     "PYTHONPATH",
+#     [
+#         os.path.join(config.mlir_obj_dir, "python_packages", "standalone"),
+#     ],
+#     append_path=True,
+# )

--- a/tests/lit.site.cfg.py.in
+++ b/tests/lit.site.cfg.py.in
@@ -1,0 +1,13 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+config.llvm_tools_dir = lit_config.substitute("@LLVM_TOOLS_DIR@")
+config.mlir_obj_dir = "@MLIR_BINARY_DIR@"
+config.llvm_shlib_ext = "@SHLIBEXT@"
+config.project_binary_dir = "@PROJECT_BINARY_DIR@"
+config.project_source_dir = "@PROJECT_SOURCE_DIR@"
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/tests/lit.cfg.py")


### PR DESCRIPTION
This introduces all needed CMake setup to be able to run tests using `lit`. As well, adds basic tests that do basic lowering using mlir tools: `mlir-opt` and `mlir-cpu-runner`.

After building you can run the tests by invoking the target `check-mlir-tutorial`:

```bash
ninja -C build check-mlir-tutorial
```